### PR TITLE
Layer 1: Rewrite Shorts links in the DOM to skip the Shorts player

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,31 +1,114 @@
 /**
- * Highly efficient redirect for YouTube Shorts to the standard watch player.
+ * Extract the YouTube video ID from a Shorts path.
+ * @param {string} pathname - The path part of a URL (e.g., "/shorts/VIDEO_ID")
+ * @returns {string|null} The video ID, or null if this is not a Shorts video URL.
+ */
+function getShortsVideoId(pathname) {
+    if (!pathname || !pathname.startsWith("/shorts/")) return null;
+
+    // /shorts/VIDEO_ID -> split by "/" and take index 2.
+    // Use /[?#]/ to cut off any query params or fragments.
+    const videoId = pathname.split("/")[2]?.split(/[?#]/)[0];
+    return videoId || null;
+}
+
+/**
+ * Fallback redirect for the current page. Covers direct loads, links followed
+ * from outside YouTube, and any anchor that wasn't rewritten in time.
  * @param {string} urlPath - The path part of the URL (e.g., "/shorts/12345")
  */
 function handleRedirect(urlPath) {
-    // Fast path check
-    if (!urlPath || !urlPath.startsWith("/shorts/")) return;
-
-    // Extract the video ID. /shorts/VIDEO_ID -> split by / and take index 2.
-    // Use /[?#]/ regex to cut off any query params or fragments.
-    const videoId = urlPath.split("/")[2]?.split(/[?#]/)[0];
+    const videoId = getShortsVideoId(urlPath);
     if (!videoId) return;
 
-    // Preserve any existing query parameters and just change the video ID and path.
+    // Preserve any existing query parameters and just change the path and video ID.
     const newUrl = new URL(window.location.href);
     newUrl.pathname = "/watch";
     newUrl.searchParams.set("v", videoId);
 
-    // console.log("Redirecting to normal player:", videoId);
     window.location.replace(newUrl.toString());
 }
 
-// 1. Initial check (runs as soon as the script is injected)
+/**
+ * Rewrite a single anchor's href from /shorts/ID to /watch?v=ID, in place. This
+ * is what avoids the visible Shorts-player flash: the link points at the normal
+ * player before the user ever clicks it.
+ * @param {Element} a - A candidate anchor element.
+ */
+function rewriteAnchor(a) {
+    const href = a.getAttribute("href");
+    // Cheap reject before constructing a URL.
+    if (!href || href.indexOf("/shorts/") === -1) return;
+
+    let url;
+    try {
+        // Resolve against the origin so relative and absolute hrefs both work.
+        url = new URL(href, window.location.origin);
+    } catch {
+        return;
+    }
+
+    const videoId = getShortsVideoId(url.pathname);
+    // Leaves "/shorts" (the feed) and "/@channel/shorts" (channel tab) untouched.
+    if (!videoId) return;
+
+    url.pathname = "/watch";
+    url.searchParams.set("v", videoId);
+
+    // Preserve the original relative/absolute form to match YouTube's own markup.
+    const isAbsolute = /^https?:\/\//i.test(href);
+    a.setAttribute(
+        "href",
+        isAbsolute ? url.href : url.pathname + url.search + url.hash
+    );
+}
+
+/**
+ * Rewrite every Shorts anchor within a DOM subtree. The root itself may be an anchor.
+ * @param {Node} root - An element or document to scan.
+ */
+function rewriteShortsLinks(root) {
+    // Only elements (1) and documents (9) can be queried.
+    if (root.nodeType !== 1 && root.nodeType !== 9) return;
+
+    if (root.matches && root.matches('a[href*="/shorts/"]'))
+        rewriteAnchor(root);
+    if (root.querySelectorAll) {
+        root.querySelectorAll('a[href*="/shorts/"]').forEach(rewriteAnchor);
+    }
+}
+
+// 1. Fallback redirect (runs as soon as the script is injected).
 handleRedirect(window.location.pathname);
 
-// 2. Listen for YouTube internal navigation
-// This event is fired by YouTube's own framework before the next page starts loading.
+// 2. Listen for YouTube internal navigation. This event is fired by YouTube's own
+// framework before the next page starts loading.
 document.addEventListener("yt-navigate-start", (e) => {
     const url = e.detail?.url;
     if (url) handleRedirect(url);
 });
+
+// 3. Proactively rewrite Shorts links in the DOM so clicks skip the Shorts player.
+// YouTube is a single-page app that streams content in lazily and recycles anchor
+// nodes (virtualized lists), so we watch for both added nodes and href changes.
+// A rewritten href no longer contains "/shorts/", so the attribute mutation it
+// triggers is rejected by rewriteAnchor's cheap check -- no infinite loop.
+const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+        if (mutation.type === "attributes") {
+            if (mutation.target.nodeType === 1) rewriteAnchor(mutation.target);
+        } else {
+            for (const node of mutation.addedNodes) rewriteShortsLinks(node);
+        }
+    }
+});
+
+observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["href"],
+});
+
+// Sweep anything already present when the script runs.
+rewriteShortsLinks(document);


### PR DESCRIPTION
Implements **Layer 1** (sub-issue #8) of epic #7 — the in-page click fix for #6.

## What

Proactively rewrites `/shorts/ID` anchor links to `/watch?v=ID` in the DOM so clicking a Short on YouTube (homepage, search, related panel) opens the normal player directly — no Shorts-player flash.

- Factor out `getShortsVideoId(pathname)`, shared with the fallback redirect.
- `rewriteAnchor` rewrites a single anchor in place: resolves relative + absolute hrefs, preserves the original form, and leaves `/shorts` (feed) and `/@channel/shorts` (tab) untouched.
- A `MutationObserver` (added nodes + `href` changes) handles YouTube's lazily-streamed and recycled anchors; an initial sweep covers anything already in the DOM.
- The existing `handleRedirect` + `yt-navigate-start` redirect stays as a fallback (direct loads, external links, missed anchors). No infinite loop: a rewritten href no longer contains `/shorts/`, so the resulting attribute mutation is rejected.

## Testing

- `bunx prettier --check src/main.js` — clean.
- Unit test of the pure URL logic, 11 cases, all pass (relative/absolute, query/hash preserved, feed/channel/watch left unchanged).
- Manual cross-browser verification (hover shows `/watch`, click → no flash) is part of the final evaluation of the feature branch.

Base is `feature/no-shorts-flash` per the agreed workflow (sub-issue PRs merge into the feature branch, not `main`).

Part of #7.
