### PR TITLE
Layer 2: Redirect direct /shorts/ loads via declarativeNetRequest

### DIFF
--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -4,7 +4,17 @@
     "version": "1.4.3",
     "description": "Plays YouTube Shorts in the normal YouTube player so you can rewind the videos.",
     "icons": { "48": "images/icon-48.png", "128": "images/icon-128.png" },
+    "permissions": ["declarativeNetRequestWithHostAccess"],
     "host_permissions": ["*://*.youtube.com/*"],
+    "declarative_net_request": {
+        "rule_resources": [
+            {
+                "id": "shorts_redirect",
+                "enabled": true,
+                "path": "rules.json"
+            }
+        ]
+    },
     "content_scripts": [
         {
             "matches": ["*://*.youtube.com/*"],

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -7,13 +7,23 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "{1585f20b-4ee0-4f94-b48a-3719b091df78}",
-            "strict_min_version": "109.0",
+            "strict_min_version": "113.0",
             "data_collection_permissions": {
                 "required": ["none"]
             }
         }
     },
+    "permissions": ["declarativeNetRequestWithHostAccess"],
     "host_permissions": ["*://*.youtube.com/*"],
+    "declarative_net_request": {
+        "rule_resources": [
+            {
+                "id": "shorts_redirect",
+                "enabled": true,
+                "path": "rules.json"
+            }
+        ]
+    },
     "content_scripts": [
         {
             "matches": ["*://*.youtube.com/*"],

--- a/src/rules.json
+++ b/src/rules.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": 1,
+        "priority": 1,
+        "action": {
+            "type": "redirect",
+            "redirect": {
+                "regexSubstitution": "\\1/watch?v=\\2"
+            }
+        },
+        "condition": {
+            "regexFilter": "^(https?://[^/]+)/shorts/([\\w-]+).*$",
+            "resourceTypes": ["main_frame"]
+        }
+    }
+]


### PR DESCRIPTION
Implements **Layer 2** (sub-issue #9) of epic #7 — the direct-load fix for #6.

## What

Adds a `declarativeNetRequest` rule that redirects top-level `*://*.youtube.com/shorts/ID` requests to `/watch?v=ID` at the network layer, *before any YouTube JS runs*, so direct / typed / reloaded / external Shorts loads never flash. This complements Layer 1 (in-page SPA clicks), which DNR can't see because those are client-side route changes with no network request.

- New `src/rules.json` static ruleset (the build copies `src/*` to each build root → `rules.json`, no build-script change).
- Registered the ruleset + the least-privilege `declarativeNetRequestWithHostAccess` permission in both manifests (gated on the existing `*://*.youtube.com/*` host permission → no extra broad install warning).
- Bumped Firefox `strict_min_version` to **113** (the minimum that supports `declarativeNetRequest`).

## Rule details

- `regexFilter: ^(https?://[^/]+)/shorts/([\w-]+).*$` → `regexSubstitution: \1/watch?v=\2`. Group 1 preserves scheme+host (`www.`/`m.`), group 2 the video ID; trailing `.*$` consumes any query/fragment so the whole URL is replaced (avoids a malformed double `?`).
- `main_frame` only; requires a real ID, so the `/shorts` feed and `/@channel/shorts` tab are left alone.

## Testing

- `bun run build` — clean for both browsers; `rules.json` + updated manifests land in `_build/{firefox,chrome}`.
- `web-ext lint` (Firefox) — **0 errors**; DNR version warnings cleared by the 113 bump. (2 remaining warnings are the pre-existing `data_collection_permissions`/FF140 ones, unrelated to this PR.)
- Unit test of the rule's regex + substitution, 9 cases, all pass (incl. feed/channel/watch left unchanged).
- Runtime redirect on Firefox to be confirmed in the final cross-browser evaluation (the content-script fallback covers any Firefox DNR gap).

Base is `feature/no-shorts-flash` per the agreed workflow.

Part of #7.
