### PR TITLE
Release: bump to 1.5.0 + update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Do not enter the `TANK/` directory or read any files that are blocked by `.gitig
 
 ## Project Overview
 
-This is a cross-browser extension that redirects YouTube Shorts URLs to the normal YouTube player. The extension supports both Firefox (Manifest v2) and Chrome/Chromium (Manifest v3).
+This is a cross-browser extension that makes YouTube Shorts open in the normal YouTube player. It rewrites Shorts links in the page, redirects Shorts requests at the network layer, and redirects any Shorts URL that still loads. The extension supports both Firefox and Chrome/Chromium using Manifest V3.
 
 ## Build System
 
@@ -42,17 +42,18 @@ Build output structure:
 
 ### Core Functionality
 
-The extension consists of a single content script (`src/main.js`) that:
+The extension makes Shorts (`/shorts/VIDEO_ID`) open in the normal watch player (`/watch?v=VIDEO_ID`) using three layers:
 
-1. Detects YouTube Shorts URLs (paths starting with `/shorts/`)
-2. Extracts the video ID from the Shorts URL
-3. Redirects to the normal YouTube player (`/watch?v=VIDEO_ID`)
-4. Listens for YouTube's SPA navigation events (`yt-navigate-start`) to handle in-page navigation
+1. **DOM link rewriting** (`src/main.js`): a `MutationObserver` rewrites Shorts anchor links to the watch URL in place (handling YouTube's lazily-added and recycled links), so clicking a Short goes straight to the normal player without the Shorts player flashing first.
+2. **Network-layer redirect** (`src/rules.json`): a `declarativeNetRequest` rule redirects top-level `/shorts/` requests before the page loads, covering direct, typed, reloaded, and external Shorts links.
+3. **Fallback redirect** (`src/main.js`): on initial load and on YouTube's SPA navigation events (`yt-navigate-start`), any remaining `/shorts/` URL is redirected to the normal player.
 
 ### Manifest Differences
 
-- **Firefox** (`manifests/firefox.json`): Uses Manifest v2 with `content_scripts` only
-- **Chrome** (`manifests/chrome.json`): Uses Manifest v3 with both `content_scripts` and `host_permissions`
+Both manifests use **Manifest V3** and share `content_scripts`, `host_permissions`, the `declarativeNetRequestWithHostAccess` permission, and the `declarative_net_request` ruleset (`rules.json`).
+
+- **Firefox** (`manifests/firefox.json`): adds `browser_specific_settings.gecko` (extension ID, `strict_min_version` 113, data-collection disclosure).
+- **Chrome** (`manifests/chrome.json`): no Gecko-specific settings.
 
 Both manifests must be kept in sync for version numbers and descriptions.
 

--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "YouTube Shorts Normal Player",
-    "version": "1.4.3",
+    "version": "1.5.0",
     "description": "Plays YouTube Shorts in the normal YouTube player so you can rewind the videos.",
     "icons": { "48": "images/icon-48.png", "128": "images/icon-128.png" },
     "permissions": ["declarativeNetRequestWithHostAccess"],

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "YouTube Shorts Normal Player",
-    "version": "1.4.3",
+    "version": "1.5.0",
     "description": "Plays YouTube Shorts in the normal YouTube player so you can rewind the videos.",
     "icons": { "48": "images/icon-48.png", "128": "images/icon-128.png" },
     "browser_specific_settings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "youtube_shorts_normal_player",
-    "version": "1.4.3",
+    "version": "1.5.0",
     "license": "MIT",
     "scripts": {
         "clean": "rm -rf _build",


### PR DESCRIPTION
Implements **Release** (sub-issue #10) of epic #7.

## What

- Bumps version `1.4.3 → 1.5.0` across `package.json` and both manifests (kept in sync per AGENTS.md).
- Updates `AGENTS.md` "Core Functionality" to describe the three layers (DOM link rewriting, network-layer `declarativeNetRequest` redirect, fallback redirect) and corrects the stale "Firefox = Manifest v2" notes (both manifests are MV3).

## Verification

- Versions identical (`1.5.0`) across the three files.
- `bun run build` — clean; packages `youtube_shorts_normal_player-1.5.0.zip` for both browsers; `rules.json` + manifests present in each build dir.
- `web-ext lint` Firefox: **0 errors** (the 2 warnings are the pre-existing `data_collection_permissions`/FF140 ones, unrelated).
- `web-ext lint` Chrome: the 1 error (`ADDON_ID_REQUIRED`) + 1 warning are Firefox-specific checks misapplied by web-ext to the Chrome build (Chrome gets its ID from the Web Store), pre-existing and not introduced here.
- Prettier-clean.

Base is `feature/no-shorts-flash` per the agreed workflow.

Part of #7.
