### PR TITLE
Fix code review findings: YouTube host check + preserve query in DNR

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,15 @@ function rewriteAnchor(a) {
         return;
     }
 
+    // Only rewrite YouTube links; an external link on a YouTube page (e.g. in a
+    // video description) can also have a "/shorts/" path.
+    if (
+        url.hostname !== "youtube.com" &&
+        !url.hostname.endsWith(".youtube.com")
+    ) {
+        return;
+    }
+
     const videoId = getShortsVideoId(url.pathname);
     // Leaves "/shorts" (the feed) and "/@channel/shorts" (channel tab) untouched.
     if (!videoId) return;

--- a/src/rules.json
+++ b/src/rules.json
@@ -1,6 +1,20 @@
 [
     {
         "id": 1,
+        "priority": 2,
+        "action": {
+            "type": "redirect",
+            "redirect": {
+                "regexSubstitution": "\\1/watch?v=\\2&\\3"
+            }
+        },
+        "condition": {
+            "regexFilter": "^(https?://[^/]+)/shorts/([\\w-]+)\\?(.+)$",
+            "resourceTypes": ["main_frame"]
+        }
+    },
+    {
+        "id": 2,
         "priority": 1,
         "action": {
             "type": "redirect",


### PR DESCRIPTION
Addresses the two code review findings on #14. Merges into `feature/no-shorts-flash`, so PR #14 → `main` picks these up automatically.

## P3 — `rewriteAnchor` rewrote external `/shorts/` links (`src/main.js`)

The content script runs on all youtube.com pages, and `rewriteAnchor` only checked the *path*, not the host. An external link in a video description like `https://example.com/shorts/foo` was being rewritten to `https://example.com/watch?v=foo`. Added a host check so only `youtube.com` / `*.youtube.com` anchors are rewritten; relative links resolve to the youtube origin and still pass.

(The DNR rule was never affected — it's gated to youtube.com by `host_permissions` + `declarativeNetRequestWithHostAccess`.)

## P2 — DNR dropped the query string on direct loads (`src/rules.json`)

The single rule produced `/watch?v=ID` for `/shorts/ID?t=30`, dropping params the content-script path preserves. Split into two rules:

- **Rule 1** (priority 2) matches when a query is present and carries it through: `/shorts/ID?t=30` → `/watch?v=ID&t=30`.
- **Rule 2** (priority 1) is the no-query fallback: `/shorts/ID` → `/watch?v=ID`.

DNR applies the highest-priority matching rule, so the query is preserved when present.

## Testing

- Layer 1 logic test (12 cases) incl. `https://example.com/shorts/foo` left unchanged — all pass.
- Layer 2 logic test (10 cases) incl. `?t=30` and `?feature=share&t=10` preserved — all pass.
- `bun run build` clean; `web-ext lint` Firefox 0 errors; Prettier clean.

Part of #7.
